### PR TITLE
Add scripts for running private Tezos blockchain

### DIFF
--- a/.buildkite/check-trailing-whitespace.sh
+++ b/.buildkite/check-trailing-whitespace.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: 2019 TQ Tezos <https://tqtezos.com/>
+#
+# SPDX-License-Identifier: MPL-2.0
+
+files=$(git ls-files -- . ':!:*.patch' | xargs grep --files-with-matches --binary-files=without-match '[[:blank:]]$')
+if [[ ! -z $files ]];then
+  echo '  Files with trailing whitespace found:'
+  for f in "${files[@]}"; do
+    echo "  * $f"
+  done
+  exit 1
+fi

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: 2019 TQ Tezos <https://tqtezos.com/>
+#
+# SPDX-License-Identifier: MPL-2.0
+
+env:
+  NIX_PATH: nixpkgs=https://github.com/serokell/nixpkgs/archive/master.tar.gz
+  cur_date: "$(date +\"%Y%m%d%H%M\")"
+
+steps:
+ - command: nix run nixpkgs.reuse -c reuse lint
+   label: reuse lint
+ - command: .buildkite/check-trailing-whitespace.sh
+   label: check trailing whitespace
+ - command: "nix run -f https://github.com/serokell/crossref-verifier/archive/68a1f9d25b6e7835fea8299b18a3e6c61dbb2a5c.tar.gz -c crossref-verify"
+   label: crossref-verify
+   soft_fail: true
+ - commands: nix run nixpkgs.shellcheck -c shellcheck scripts/*
+   label: shellcheck

--- a/LICENSES/MPL-2.0.txt
+++ b/LICENSES/MPL-2.0.txt
@@ -1,0 +1,312 @@
+Mozilla Public License Version 2.0
+
+   1. Definitions
+
+1.1. "Contributor" means each individual or legal entity that creates, contributes
+to the creation of, or owns Covered Software.
+
+1.2. "Contributor Version" means the combination of the Contributions of others
+(if any) used by a Contributor and that particular Contributor's Contribution.
+
+      1.3. "Contribution" means Covered Software of a particular Contributor.
+
+1.4. "Covered Software" means Source Code Form to which the initial Contributor
+has attached the notice in Exhibit A, the Executable Form of such Source Code
+Form, and Modifications of such Source Code Form, in each case including portions
+thereof.
+
+      1.5. "Incompatible With Secondary Licenses" means
+
+(a) that the initial Contributor has attached the notice described in Exhibit
+B to the Covered Software; or
+
+(b) that the Covered Software was made available under the terms of version
+1.1 or earlier of the License, but not also under the terms of a Secondary
+License.
+
+1.6. "Executable Form" means any form of the work other than Source Code Form.
+
+1.7. "Larger Work" means a work that combines Covered Software with other
+material, in a separate file or files, that is not Covered Software.
+
+      1.8. "License" means this document.
+
+1.9. "Licensable" means having the right to grant, to the maximum extent possible,
+whether at the time of the initial grant or subsequently, any and all of the
+rights conveyed by this License.
+
+      1.10. "Modifications" means any of the following:
+
+(a) any file in Source Code Form that results from an addition to, deletion
+from, or modification of the contents of Covered Software; or
+
+(b) any new file in Source Code Form that contains any Covered Software.
+
+1.11. "Patent Claims" of a Contributor means any patent claim(s), including
+without limitation, method, process, and apparatus claims, in any patent Licensable
+by such Contributor that would be infringed, but for the grant of the License,
+by the making, using, selling, offering for sale, having made, import, or
+transfer of either its Contributions or its Contributor Version.
+
+1.12. "Secondary License" means either the GNU General Public License, Version
+2.0, the GNU Lesser General Public License, Version 2.1, the GNU Affero General
+Public License, Version 3.0, or any later versions of those licenses.
+
+1.13. "Source Code Form" means the form of the work preferred for making modifications.
+
+1.14. "You" (or "Your") means an individual or a legal entity exercising rights
+under this License. For legal entities, "You" includes any entity that controls,
+is controlled by, or is under common control with You. For purposes of this
+definition, "control" means (a) the power, direct or indirect, to cause the
+direction or management of such entity, whether by contract or otherwise,
+or (b) ownership of more than fifty percent (50%) of the outstanding shares
+or beneficial ownership of such entity.
+
+   2. License Grants and Conditions
+
+      2.1. Grants
+
+Each Contributor hereby grants You a world-wide, royalty-free, non-exclusive
+license:
+
+(a) under intellectual property rights (other than patent or trademark) Licensable
+by such Contributor to use, reproduce, make available, modify, display, perform,
+distribute, and otherwise exploit its Contributions, either on an unmodified
+basis, with Modifications, or as part of a Larger Work; and
+
+(b) under Patent Claims of such Contributor to make, use, sell, offer for
+sale, have made, import, and otherwise transfer either its Contributions or
+its Contributor Version.
+
+      2.2. Effective Date
+
+The licenses granted in Section 2.1 with respect to any Contribution become
+effective for each Contribution on the date the Contributor first distributes
+such Contribution.
+
+      2.3. Limitations on Grant Scope
+
+The licenses granted in this Section 2 are the only rights granted under this
+License. No additional rights or licenses will be implied from the distribution
+or licensing of Covered Software under this License. Notwithstanding Section
+2.1(b) above, no patent license is granted by a Contributor:
+
+(a) for any code that a Contributor has removed from Covered Software; or
+
+(b) for infringements caused by: (i) Your and any other third party's modifications
+of Covered Software, or (ii) the combination of its Contributions with other
+software (except as part of its Contributor Version); or
+
+(c) under Patent Claims infringed by Covered Software in the absence of its
+Contributions.
+
+This License does not grant any rights in the trademarks, service marks, or
+logos of any Contributor (except as may be necessary to comply with the notice
+requirements in Section 3.4).
+
+      2.4. Subsequent Licenses
+
+No Contributor makes additional grants as a result of Your choice to distribute
+the Covered Software under a subsequent version of this License (see Section
+10.2) or under the terms of a Secondary License (if permitted under the terms
+of Section 3.3).
+
+      2.5. Representation
+
+Each Contributor represents that the Contributor believes its Contributions
+are its original creation(s) or it has sufficient rights to grant the rights
+to its Contributions conveyed by this License.
+
+      2.6. Fair Use
+
+This License is not intended to limit any rights You have under applicable
+copyright doctrines of fair use, fair dealing, or other equivalents.
+
+      2.7. Conditions
+
+Sections 3.1, 3.2, 3.3, and 3.4 are conditions of the licenses granted in
+Section 2.1.
+
+   3. Responsibilities
+
+      3.1. Distribution of Source Form
+
+All distribution of Covered Software in Source Code Form, including any Modifications
+that You create or to which You contribute, must be under the terms of this
+License. You must inform recipients that the Source Code Form of the Covered
+Software is governed by the terms of this License, and how they can obtain
+a copy of this License. You may not attempt to alter or restrict the recipients'
+rights in the Source Code Form.
+
+      3.2. Distribution of Executable Form
+
+      If You distribute Covered Software in Executable Form then:
+
+(a) such Covered Software must also be made available in Source Code Form,
+as described in Section 3.1, and You must inform recipients of the Executable
+Form how they can obtain a copy of such Source Code Form by reasonable means
+in a timely manner, at a charge no more than the cost of distribution to the
+recipient; and
+
+(b) You may distribute such Executable Form under the terms of this License,
+or sublicense it under different terms, provided that the license for the
+Executable Form does not attempt to limit or alter the recipients' rights
+in the Source Code Form under this License.
+
+      3.3. Distribution of a Larger Work
+
+You may create and distribute a Larger Work under terms of Your choice, provided
+that You also comply with the requirements of this License for the Covered
+Software. If the Larger Work is a combination of Covered Software with a work
+governed by one or more Secondary Licenses, and the Covered Software is not
+Incompatible With Secondary Licenses, this License permits You to additionally
+distribute such Covered Software under the terms of such Secondary License(s),
+so that the recipient of the Larger Work may, at their option, further distribute
+the Covered Software under the terms of either this License or such Secondary
+License(s).
+
+      3.4. Notices
+
+You may not remove or alter the substance of any license notices (including
+copyright notices, patent notices, disclaimers of warranty, or limitations
+of liability) contained within the Source Code Form of the Covered Software,
+except that You may alter any license notices to the extent required to remedy
+known factual inaccuracies.
+
+      3.5. Application of Additional Terms
+
+You may choose to offer, and to charge a fee for, warranty, support, indemnity
+or liability obligations to one or more recipients of Covered Software. However,
+You may do so only on Your own behalf, and not on behalf of any Contributor.
+You must make it absolutely clear that any such warranty, support, indemnity,
+or liability obligation is offered by You alone, and You hereby agree to indemnify
+every Contributor for any liability incurred by such Contributor as a result
+of warranty, support, indemnity or liability terms You offer. You may include
+additional disclaimers of warranty and limitations of liability specific to
+any jurisdiction.
+
+   4. Inability to Comply Due to Statute or Regulation
+
+If it is impossible for You to comply with any of the terms of this License
+with respect to some or all of the Covered Software due to statute, judicial
+order, or regulation then You must: (a) comply with the terms of this License
+to the maximum extent possible; and (b) describe the limitations and the code
+they affect. Such description must be placed in a text file included with
+all distributions of the Covered Software under this License. Except to the
+extent prohibited by statute or regulation, such description must be sufficiently
+detailed for a recipient of ordinary skill to be able to understand it.
+
+   5. Termination
+
+5.1. The rights granted under this License will terminate automatically if
+You fail to comply with any of its terms. However, if You become compliant,
+then the rights granted under this License from a particular Contributor are
+reinstated (a) provisionally, unless and until such Contributor explicitly
+and finally terminates Your grants, and (b) on an ongoing basis, if such Contributor
+fails to notify You of the non-compliance by some reasonable means prior to
+60 days after You have come back into compliance. Moreover, Your grants from
+a particular Contributor are reinstated on an ongoing basis if such Contributor
+notifies You of the non-compliance by some reasonable means, this is the first
+time You have received notice of non-compliance with this License from such
+Contributor, and You become compliant prior to 30 days after Your receipt
+of the notice.
+
+5.2. If You initiate litigation against any entity by asserting a patent infringement
+claim (excluding declaratory judgment actions, counter-claims, and cross-claims)
+alleging that a Contributor Version directly or indirectly infringes any patent,
+then the rights granted to You by any and all Contributors for the Covered
+Software under Section 2.1 of this License shall terminate.
+
+5.3. In the event of termination under Sections 5.1 or 5.2 above, all end
+user license agreements (excluding distributors and resellers) which have
+been validly granted by You or Your distributors under this License prior
+to termination shall survive termination.
+
+   6. Disclaimer of Warranty
+
+Covered Software is provided under this License on an "as is" basis, without
+warranty of any kind, either expressed, implied, or statutory, including,
+without limitation, warranties that the Covered Software is free of defects,
+merchantable, fit for a particular purpose or non-infringing. The entire risk
+as to the quality and performance of the Covered Software is with You. Should
+any Covered Software prove defective in any respect, You (not any Contributor)
+assume the cost of any necessary servicing, repair, or correction. This disclaimer
+of warranty constitutes an essential part of this License. No use of any Covered
+Software is authorized under this License except under this disclaimer.
+
+   7. Limitation of Liability
+
+Under no circumstances and under no legal theory, whether tort (including
+negligence), contract, or otherwise, shall any Contributor, or anyone who
+distributes Covered Software as permitted above, be liable to You for any
+direct, indirect, special, incidental, or consequential damages of any character
+including, without limitation, damages for lost profits, loss of goodwill,
+work stoppage, computer failure or malfunction, or any and all other commercial
+damages or losses, even if such party shall have been informed of the possibility
+of such damages. This limitation of liability shall not apply to liability
+for death or personal injury resulting from such party's negligence to the
+extent applicable law prohibits such limitation. Some jurisdictions do not
+allow the exclusion or limitation of incidental or consequential damages,
+so this exclusion and limitation may not apply to You.
+
+   8. Litigation
+
+Any litigation relating to this License may be brought only in the courts
+of a jurisdiction where the defendant maintains its principal place of business
+and such litigation shall be governed by laws of that jurisdiction, without
+reference to its conflict-of-law provisions. Nothing in this Section shall
+prevent a party's ability to bring cross-claims or counter-claims.
+
+   9. Miscellaneous
+
+This License represents the complete agreement concerning the subject matter
+hereof. If any provision of this License is held to be unenforceable, such
+provision shall be reformed only to the extent necessary to make it enforceable.
+Any law or regulation which provides that the language of a contract shall
+be construed against the drafter shall not be used to construe this License
+against a Contributor.
+
+   10. Versions of the License
+
+      10.1. New Versions
+
+Mozilla Foundation is the license steward. Except as provided in Section 10.3,
+no one other than the license steward has the right to modify or publish new
+versions of this License. Each version will be given a distinguishing version
+number.
+
+      10.2. Effect of New Versions
+
+You may distribute the Covered Software under the terms of the version of
+the License under which You originally received the Covered Software, or under
+the terms of any subsequent version published by the license steward.
+
+      10.3. Modified Versions
+
+If you create software not governed by this License, and you want to create
+a new license for such software, you may create and use a modified version
+of this License if you rename the license and remove any references to the
+name of the license steward (except to note that such modified license differs
+from this License).
+
+10.4. Distributing Source Code Form that is Incompatible With Secondary Licenses
+
+If You choose to distribute Source Code Form that is Incompatible With Secondary
+Licenses under the terms of this version of the License, the notice described
+in Exhibit B of this License must be attached. Exhibit A - Source Code Form
+License Notice
+
+This Source Code Form is subject to the terms of the Mozilla Public License,
+v. 2.0. If a copy of the MPL was not distributed with this file, You can obtain
+one at http://mozilla.org/MPL/2.0/.
+
+If it is not possible or desirable to put the notice in a particular file,
+then You may include the notice in a location (such as a LICENSE file in a
+relevant directory) where a recipient would be likely to look for such a notice.
+
+You may add additional accurate notices of copyright ownership.
+
+Exhibit B - "Incompatible With Secondary Licenses" Notice
+
+This Source Code Form is "Incompatible With Secondary Licenses", as defined
+by the Mozilla Public License, v. 2.0.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,263 @@
-# private-tezos-blockchain
-Scripts for running private Tezos blockchain
+# Running private blockchain
+
+This doc will describe how to run your own private Tezos blockchain.
+
+## General overview
+
+In order to run a private blockchain, you should do the following:
+* Generate new genesis key, and build patched binaries
+(using `build-patched-binaries.sh` script).
+* Run a bunch of nodes and bakers, at least two, but the more the better
+(using `start-baker.sh` script).
+* Customize chain parameters to your taste and activate the procotol
+(using `activate-protocol.sh` script).
+* Play with your chain.
+
+More detailed instructions are presented further.
+
+## Prerequisites
+
+Since running a private blockchain requires compiling patched Tezos binaries from
+scratch, you will have to install the following dependencies:
+```
+rsync git m4 build-essential patch unzip bubblewrap wget pkg-config
+libgmp-dev libev-dev libhidapi-dev which opam
+```
+These dependencies are also described [here](https://tezos.gitlab.io/introduction/howtoget.html#build-from-sources).
+
+In order to install them using a Debian or RedHat-based distro, run one of the following
+commands:
+```sh
+# Debian and apt
+sudo apt update && sudo apt install rsync git m4 build-essential patch unzip \
+     bubblewrap wget pkg-config libgmp-dev libev-dev libhidapi-dev which
+# RedHat and yum
+sudo yum update && sudo yum install rsync git m4 patch unzip make \
+     bubblewrap wget gmp-devel libev-devel perl-Pod-Html pkgconfig hidapi-devel which
+```
+In order to install `opam`, run the following commands:
+```sh
+wget https://github.com/ocaml/opam/releases/download/2.0.3/opam-2.0.3-x86_64-linux
+sudo cp opam-2.0.3-x86_64-linux /usr/local/bin/opam
+sudo chmod a+x /usr/local/bin/opam
+```
+
+## Generating new genesis public key and building patched binaries
+
+First step for running the private blockchain is generating a new genesis public key and
+building patched Tezos binaries. [build-patched-binaries.sh](./scripts/build-patched-binaries.sh)
+shell script will build these patched binaries.
+
+Note that you may have to adjust this script for your needs, e.g. `babylonnet` branch can be changed
+to `carthagenet`. Another case is that genesis public key can be moved from
+`src/proto_genesis/lib_protocol/data.ml` to another file.
+
+There are two ways to use this script:
+* You are the one who initiates the new private blockchain creation (the so-called dictator).
+Thus, you'll have to generate a new genesis public key. In order to do that, you can run
+the following command:
+```sh
+./build-patched-binaries.sh --base-dir dictator
+```
+After running this command, the new genesis public-key will be stored in a `dictator/genesis_key.txt` file,
+so that you can share this key with other users of your private blockchain.
+Apart from file with the new genesis public key, the `dictator` directory will also contain
+patched Tezos binaries required for running the private blockchain.
+In addition to this, the `dictator` directory will have a `client` folder, which will contain `tezos-client`
+related files, e.g. it will contain the public key hash, public and secret keys for the `genesis` account,
+in `dictator/client/public_key_hashs`, `dictator/client/public_keys` and `dictator/client/secret_keys`.
+files respectively. This hash and keys will be used later in protocol activation.
+To get information about the `genesis` account, run:
+```sh
+./dictator/tezos-client -d dictator/client show address genesis
+```
+* Someone provided you a genesis public key. In this case, you should run the following command:
+```sh
+./build-patched-binaries.sh --base-dir user --genesis-key <provided key>
+```
+After running this command, the `user` directory will contain patched Tezos binaries.
+
+## Running baker
+
+In order to run baker, you should use the [start-baker.sh](./scripts/start-baker.sh)
+shell script, for this you will need Tezos binaries from the previous step.
+Let's suppose baker built binaries using `baker` as a `base-dir` with some provided genesis key.
+Also, on this step you need to specify an IP address on which baker can be accessed on the
+network.
+Here is an example of script usage:
+```sh
+./scripts/start-baker.sh --base-dir baker \
+  --tezos-client baker/tezos-client --tezos-node baker/tezos-node \
+  --tezos-baker baker/tezos-baker-005-PsBabyM1 --tezos-endorser baker/tezos-endorser-005-PsBabyM1 \
+  --net-addr 10.147.19.192:8732
+  --peer 10.147.19.49:8732
+```
+Note that you should provide at least one peer to make the node communicate with the chain (e.g. you
+can provide address of the dictator node).
+This script will generate the new node identity in the `baker/node` directory and the new Tezos account
+with `baker` alias (all `tezos-client` related files will be accessible in the `baker/client` directory),
+this `baker` public key should be provided to the chain dictator (person, who initiated
+the private chain creation). This public key can be found in the `baker/client/public_keys` file.
+After identity and account generation, this script will run `tezos-node` along
+with baker and endorser daemons in the background. Now, once the new protocol is activated, it will start baking blocks.
+
+To stop the baker, do the following:
+```sh
+./scripts/start-baker.sh --base-dir baker stop
+```
+
+We recomend having at least two nodes and bakers in your private chain, but the more the better.
+
+## Activating procotol and starting blockchain
+
+After building and running the baker on the dictator machine, the dictator should activate protocol
+and bake the first block. In order to do that, one should use
+[activate-protocol.sh](./scripts/activate-protocol.sh) shell script.
+It will activate the new protocol and bake the first block, after that the private blockchain will
+actually start.
+
+Let's suppose dictator built binaries and started baker using `dictator` as a `base-dir`.
+E.g. the following commands were executed:
+```sh
+./scripts/build-patched-binaries.sh --base-dir dictator
+./scripts/start-baker.sh --base-dir dictator \
+  --tezos-client dictator/tezos-client --tezos-node dictator/tezos-node \
+  --tezos-baker dictator/tezos-baker-005-PsBabyM1 --tezos-endorser dictator/tezos-endorser-005-PsBabyM1
+  --net-addr 10.147.19.192:8732
+```
+Now the blockchain is ready to be launched. In order to launch it, the dictator should run the following:
+```sh
+./scripts/activate-protocol.sh --base-dir dictator --tezos-client \
+  dictator/tezos-client --parameters parameters.json
+```
+`parameters.json` describes different chain parameters, here is a sample parameter file:
+```
+{
+  "bootstrap_accounts": [
+    [
+      "edpkvRk8HnYe9tAgTEAYEhSo4N7qcrjoAFnj4ZiRb7DxFDijdrXxbK",
+      "4000000000000"
+    ],
+    [
+      "edpkvUS1z9QGXr6f89dNF5WyeRCFuK6PYWYrMHcpU9kQ2TevD66fDG",
+      "4000000000000"
+    ],
+    [
+      "edpktezaD1wnUa5pT2pvj1JGHNey18WGhPc9fk9bbppD33KNQ2vH8R",
+      "4000000000000"
+    ]
+  ],
+  "preserved_cycles": 2,
+  "blocks_per_cycle": 8,
+  "blocks_per_commitment": 4,
+  "blocks_per_roll_snapshot": 4,
+  "blocks_per_voting_period": 64,
+  "time_between_blocks": [
+    "10",
+    "20"
+  ],
+  "endorsers_per_block": 32,
+  "hard_gas_limit_per_operation": "800000",
+  "hard_gas_limit_per_block": "8000000",
+  "proof_of_work_threshold": "-1",
+  "tokens_per_roll": "8000000000",
+  "michelson_maximum_type_size": 1000,
+  "seed_nonce_revelation_tip": "125000",
+  "origination_size": 257,
+  "block_security_deposit": "512000000",
+  "endorsement_security_deposit": "64000000",
+  "block_reward": "16000000",
+  "endorsement_reward": "2000000",
+  "cost_per_byte": "1000",
+  "hard_storage_limit_per_operation": "60000",
+  "test_chain_duration": "1966080",
+  "quorum_min": 2000,
+  "quorum_max": 7000,
+  "min_proposal_quorum": 500,
+  "initial_endorsers": 1,
+  "delay_per_missing_endorsement": "1"
+}
+```
+In this configuration, `bootstrap_accounts` has information about account public keys
+which will have some tokens (4M of tez in this example) after the chain start. Note
+that all bakers should have some tokens, thus, they should be listed in `bootstrap_accounts`.
+
+## Using private chain
+
+Once the protocol is activated, you can play with the new chain.
+For example, you can transfer some tokens from one account to another using `tezos-client`.
+You will need either a local or a remote node for this.
+
+Account `alice` has 4m of tez as a bootstrap account, `alice`'s account info
+(its public key is listed in `bootstrap_accounts`):
+```
+Hash: tz1akcPmG1Kyz2jXpS4RvVJ8uWr7tsiT9i6A
+Public Key: edpktezaD1wnUa5pT2pvj1JGHNey18WGhPc9fk9bbppD33KNQ2vH8R
+Secret Key: unencrypted:edsk2vKVH2BNwKrxJrvbRvuHnu4FW17Jrs2Uy2TzR2fxipikTJJ1aG
+```
+Note that `alice` should be a known alias for your `tezos-client`. In order to add it,
+do the following
+```sh
+$ tezos-client import secret key alice unencrypted:edsk2vKVH2BNwKrxJrvbRvuHnu4FW17Jrs2Uy2TzR2fxipikTJJ1aG
+```
+However, unencrypted secret key usage is unsafe and used to provide more simplicity in this manual.
+Consider not using them if you care about privacy (even in a private blockchain without real money).
+In order to encrypt bakers and genesis secret keys, you can provide an `--encrypted` flag
+to `build-patched-binaries.sh` and `start-baker.sh` scripts.
+
+Let's generate a new account named `bob`:
+```sh
+$ tezos-client gen keys bob
+$ tezos-client show address bob
+Hash: tz1iW2e1i355D57GSuBHw928mJkuCwcZZWmk
+Public Key: edpku66KahHGQsthyuHmsYm829xnH6jWXiapkyaNf1HspXx5VKKPSu
+```
+
+And transfer some tokens:
+```sh
+$ tezos-client transfer 100 from alice to bob --burn-cap 0.257
+```
+
+After this, `bob` will have some tokens:
+```sh
+$ tezos-client get balance for bob
+100.0 ꜩ
+```
+
+## Additional notes
+
+Consider using different `base-dir`s for different private chains, otherwise you
+highly likely will encounter baking errors. Also, nodes from different chains shouldn't be able
+to communicate with each other.
+
+### Creating peer-to-peer network
+
+It is convenient to use a dedicated peer-to-peer network in order to run private
+blockchain.
+
+One way to do that is to use the [ZeroTier](https://www.zerotier.com/) service.
+
+In order to create and use peer-to-peer network, you should do the following steps:
+
+1. Create a new ZeroTier account.
+
+2. Download the ZeroTier VPN service for your OS (Mac, Windows and Linux versions
+are available).
+
+3. Download and install the VPN service. Mac, Windows and Linux versions are available.
+Once installed, your machine will be associated with a Node ID (10-digit address).
+
+
+4. Go to the Network section of ZeroTier Central and create a new network.
+New network will be assotiated with Network ID.
+In order to join the Zerotier network run `sudo zerotier-cli join <network-id>`
+Then, ask participants to join. Use the Node IDs that were provided for your
+machine to add your machine to the network.
+
+5. Ask other participants to also create a ZeroTier account and join the network you just created.
+
+Once you have joined the network, you will be assigned an IP-address, that you can share with other
+participants.
+
+To find this IP-address, simply run `ifconfig`, the name of ZeroTier network interface
+starts with `zt` prefix.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+<!--
+   - SPDX-FileCopyrightText: 2019 TQ Tezos <https://tqtezos.com/>
+   -
+   - SPDX-License-Identifier: MPL-2.0
+   -->
+
 # Running private blockchain
 
 This doc will describe how to run your own private Tezos blockchain.

--- a/scripts/activate-protocol.sh
+++ b/scripts/activate-protocol.sh
@@ -1,4 +1,8 @@
 #! /usr/bin/env bash
+# SPDX-FileCopyrightText: 2019 TQ Tezos <https://tqtezos.com/>
+#
+# SPDX-License-Identifier: MPL-2.0
+
 set -euo pipefail
 
 export TEZOS_CLIENT_UNSAFE_DISABLE_DISCLAIMER="Y"

--- a/scripts/activate-protocol.sh
+++ b/scripts/activate-protocol.sh
@@ -71,17 +71,17 @@ done
 
 exit_flag="false"
 
-if [[ -z ${tezos_client-} ]]; then
+if [[ -z ${tezos_client:-} ]]; then
     echo "\"--tezos-client\" wasn't provided."
     exit_flag="true"
 fi
 
-if [[ -z ${base_dir-} ]]; then
+if [[ -z ${base_dir:-} ]]; then
     echo "\"--base-dir\" wasn't provided."
     exit_flag="true"
 fi
 
-if [[ -z ${parameters-} ]]; then
+if [[ -z ${parameters:-} ]]; then
     echo "\"--parameters\" wasn't provided."
     exit_flag="true"
 fi

--- a/scripts/activate-protocol.sh
+++ b/scripts/activate-protocol.sh
@@ -1,0 +1,91 @@
+#! /usr/bin/env bash
+set -euo pipefail
+
+export TEZOS_CLIENT_UNSAFE_DISABLE_DISCLAIMER="Y"
+
+activate_protocol() {
+    "$tezos_client" -d "$client_dir" --block genesis activate protocol \
+      "$protocol" with fitness "$fitness" and key genesis and parameters "$parameters"
+}
+bake_block() {
+    "$tezos_client" -d "$client_dir" bake for baker --minimal-timestamp
+}
+
+usage() {
+    echo "This script will activate a new protocol and bake the first block."
+    echo "OPTIONS:"
+    echo "  --base-dir <filepath>. Base directory for storing tezos-client"
+    echo "    data."
+    echo "  --tezos-client <filepath>. Path for patched tezos-client executable"
+    echo "  --parameters <filepath>. Path to JSON file with protocol parameters."
+    echo "  [--fitness <int>]. Protocol activation fitness, default value is $fitness."
+    echo "  [--protocol <protocol-name>]. Protocol to activate, default value is"
+    echo "  $protocol"
+
+}
+
+protocol="PsBabyM1eUXZseaJdmXFApDSBqj8YBfwELoxZHHW77EMcAbbwAS"
+fitness="25"
+
+if [[ $# -eq 0 || $1 == "--help" ]]; then
+    usage
+    exit 1
+fi
+
+while true; do
+    if [[ $# -eq 0 ]]; then
+        break
+    fi
+    case "$1" in
+        --base-dir | -d )
+            base_dir="$2"
+            shift 2
+            ;;
+        --tezos-client)
+            tezos_client="$2"
+            shift 2
+            ;;
+        --parameters)
+            parameters="$2"
+            shift 2
+            ;;
+        --fitness)
+            fitness="$2"
+            shift 2
+            ;;
+        --procotol)
+            protocol="$2"
+            shift 2
+            ;;
+        *)
+            echo "Unexpected option \"$1\"."
+            usage
+            exit 1
+            ;;
+    esac
+done
+
+exit_flag="false"
+
+if [[ -z ${tezos_client-} ]]; then
+    echo "\"--tezos-client\" wasn't provided."
+    exit_flag="true"
+fi
+
+if [[ -z ${base_dir-} ]]; then
+    echo "\"--base-dir\" wasn't provided."
+    exit_flag="true"
+fi
+
+if [[ -z ${parameters-} ]]; then
+    echo "\"--parameters\" wasn't provided."
+    exit_flag="true"
+fi
+
+[[ $exit_flag == "true" ]] && exit 1
+
+mkdir -p "$base_dir"
+client_dir="$base_dir/client"
+mkdir -p "$client_dir"
+activate_protocol
+bake_block

--- a/scripts/build-patched-binaries.sh
+++ b/scripts/build-patched-binaries.sh
@@ -1,4 +1,8 @@
 #! /usr/bin/env bash
+# SPDX-FileCopyrightText: 2019 TQ Tezos <https://tqtezos.com/>
+#
+# SPDX-License-Identifier: MPL-2.0
+
 set -euo pipefail
 
 export TEZOS_CLIENT_UNSAFE_DISABLE_DISCLAIMER="Y"

--- a/scripts/build-patched-binaries.sh
+++ b/scripts/build-patched-binaries.sh
@@ -1,0 +1,99 @@
+#! /usr/bin/env bash
+set -euo pipefail
+
+export TEZOS_CLIENT_UNSAFE_DISABLE_DISCLAIMER="Y"
+
+gen_genesis_key() {
+    # download tezos-client if not presented to generate new public key
+    if [[ ! -f $base_dir/tezos-client ]]; then
+        wget https://github.com/serokell/tezos-packaging/releases/download/202001141534/tezos-client-babylonnet-b8731913 \
+        -O "$base_dir"/tezos-client
+    fi
+    tezos_client="$base_dir/tezos-client"
+    chmod +x "$tezos_client"
+    if [[ $encrypted_flag == "true" ]]; then
+        "$tezos_client" -d "$client_dir" gen keys genesis --encrypted --force
+    else
+        "$tezos_client" -d "$client_dir" gen keys genesis --force
+    fi
+    genesis_key="$("$tezos_client" -d "$client_dir" show address genesis \
+      | sed --quiet --expression='s/^.*Public Key: //p'
+    )"
+    echo "Genesis key:"
+    echo "$genesis_key" | tee "$base_dir/genesis_key.txt"
+    echo
+
+}
+
+usage() {
+    echo "This script will compile the tezos binaries from scratch using"
+    echo "a newly generated or provided public key."
+    echo "OPTIONS:"
+    echo "  --base-dir <filepath>. Base directory for compiled binaries"
+    echo "    and genesis account."
+    echo "  [--genesis-key <public-key>]. Genesis public key used for binary compiling."
+    echo "    If not provided, this script will generate a new genesis public key."
+    echo "  [--encrypted]. Define whether the generated genesis secret key will be encrypted"
+}
+
+if [[ $# -eq 0 || $1 == "--help" ]]; then
+    usage
+    exit 1
+fi
+
+encrypted_flag=false
+genesis_key=""
+while true; do
+    if [[ $# -eq 0 ]]; then
+        break
+    fi
+    case "$1" in
+        --base-dir | -d )
+            base_dir="$2"
+            shift 2
+            ;;
+        --genesis-key)
+            genesis_key="$2"
+            shift 2
+            ;;
+        --encrypted)
+            encrypted_flag=true
+            shift
+            ;;
+        *)
+            echo "Unexpected option \"$1\"."
+            usage
+            exit 1
+            ;;
+
+    esac
+done
+
+if [[ -z ${base_dir-} ]]; then
+    echo "\"--base-dir\" wasn't provided."
+    exit 1
+fi
+
+mkdir -p "$base_dir"
+client_dir="$base_dir/client"
+mkdir -p "$client_dir"
+
+[[ -z $genesis_key ]] && gen_genesis_key
+
+cd "$base_dir"
+# You can change base branch for your binaries here
+git clone --single-branch --branch babylonnet https://gitlab.com/tezos/tezos.git --depth 1
+cd tezos
+# Update this once genesis public key is moved to another file
+sed -i s/edpkugeDwmwuwyyD3Q5enapgEYDxZLtEUFFSrvVwXASQMVEqsvTqWu/"$genesis_key"/ \
+    src/proto_genesis/lib_protocol/data.ml
+
+opam init --bare
+make build-deps && eval "$(opam env)" && make
+chmod +x tezos-*
+cp tezos-client ../
+cp tezos-node ../
+cp tezos-endorser-* ../
+cp tezos-baker-* ../
+cd ..
+rm -rf tezos

--- a/scripts/build-patched-binaries.sh
+++ b/scripts/build-patched-binaries.sh
@@ -73,7 +73,7 @@ while true; do
     esac
 done
 
-if [[ -z ${base_dir-} ]]; then
+if [[ -z ${base_dir:-} ]]; then
     echo "\"--base-dir\" wasn't provided."
     exit 1
 fi

--- a/scripts/start-baker.sh
+++ b/scripts/start-baker.sh
@@ -1,4 +1,8 @@
 #! /usr/bin/env bash
+# SPDX-FileCopyrightText: 2019 TQ Tezos <https://tqtezos.com/>
+#
+# SPDX-License-Identifier: MPL-2.0
+
 set -euo pipefail
 
 export TEZOS_CLIENT_UNSAFE_DISABLE_DISCLAIMER="Y"

--- a/scripts/start-baker.sh
+++ b/scripts/start-baker.sh
@@ -14,7 +14,7 @@ gen_node_identity() {
 
 start_node() {
     node_args=("--data-dir" "$node_dir" "--rpc-addr" "localhost:8732" "--net-addr" "$net_addr" "--no-bootstrap-peers" "--bootstrap-threshold" "1")
-    for peer in "${peers[@]-}"; do
+    for peer in "${peers[@]:-}"; do
         node_args+=("--peer" "$peer")
     done
     ("$tezos_node" run "${node_args[@]}" &>"$base_dir/node.log") &
@@ -124,32 +124,32 @@ fi
 
 exit_flag="false"
 
-if [[ -z ${base_dir-} ]]; then
+if [[ -z ${base_dir:-} ]]; then
     echo "\"--base-dir\" wasn't provided."
     exit_flag="true"
 fi
 
-if [[ -z ${tezos_client-} ]]; then
+if [[ -z ${tezos_client:-} ]]; then
     echo "\"--tezos-client\" wasn't provided."
     exit_flag="true"
 fi
 
-if [[ -z ${tezos_node-} ]]; then
+if [[ -z ${tezos_node:-} ]]; then
     echo "\"--tezos-node\" wasn't provided."
     exit_flag="true"
 fi
 
-if [[ -z ${tezos_baker-} ]]; then
+if [[ -z ${tezos_baker:-} ]]; then
     echo "\"--tezos-baker\" wasn't provided."
     exit_flag="true"
 fi
 
-if [[ -z ${tezos_endorser-} ]]; then
+if [[ -z ${tezos_endorser:-} ]]; then
     echo "\"--tezos-endorser\" wasn't provided."
     exit_flag="true"
 fi
 
-if [[ -z ${net_addr-} ]]; then
+if [[ -z ${net_addr:-} ]]; then
     echo "\"--net-addr\" wasn't provided."
     exit_flag="true"
 fi

--- a/scripts/start-baker.sh
+++ b/scripts/start-baker.sh
@@ -1,0 +1,166 @@
+#! /usr/bin/env bash
+set -euo pipefail
+
+export TEZOS_CLIENT_UNSAFE_DISABLE_DISCLAIMER="Y"
+
+gen_node_identity() {
+    echo "Set up new node:"
+    "$tezos_node" identity generate --data-dir "$node_dir"
+}
+
+start_node() {
+    node_args=("--data-dir" "$node_dir" "--rpc-addr" "localhost:8732" "--net-addr" "$net_addr" "--no-bootstrap-peers" "--bootstrap-threshold" "1")
+    for peer in "${peers[@]-}"; do
+        node_args+=("--peer" "$peer")
+    done
+    ("$tezos_node" run "${node_args[@]}" &>"$base_dir/node.log") &
+    echo "$!" >| "$base_dir/node_pid.txt"
+}
+
+gen_baker_account() {
+    if [[ $encrypted_flag == "true" ]]; then
+        "$tezos_client" -d "$client_dir" gen keys baker --encrypted
+    else
+        "$tezos_client" -d "$client_dir" gen keys baker
+    fi
+    echo "Baker info:"
+    "$tezos_client" -d "$client_dir" show address baker -S
+    echo
+}
+
+start_baker() {
+    ("$tezos_baker" -d "$client_dir" run with local node "$node_dir" baker &>"$base_dir/baker.log") &
+}
+
+start_endorser() {
+    ("$tezos_endorser" -d "$client_dir" run baker &>"$base_dir/endorser.log") &
+}
+
+usage() {
+    echo "This script will run tezos-node along with baker and endorser daemons in the background."
+    echo "In order to stop node and daemons run \"./start-baker.sh --base-dir <filepath> stop\"."
+    echo "OPTIONS:"
+    echo "  --base-dir <filepath>. Base directory for storing tezos-node and"
+    echo "    tezos-client data, also for storing node, baker and endorser logs."
+    echo "  --tezos-client <filepath>. Path for patched tezos-client executable"
+    echo "  --tezos-node <filepath>. Path for patched tezos-node executable"
+    echo "  --tezos-baker <filepath>. Path for patched tezos-baker executable"
+    echo "  --tezos-endorser <filepath>. Path for patched tezos-endorser executable"
+    echo "  --net-addr <net-addr>. Define net address of the baker node"
+    echo "  [--peer <net-addr>]. Node peer address. Possible to provide"
+    echo "    zero or more peers. Note, that you have to provide at least one peer"
+    echo "    for the baker (e.g. use dictator node), otherwise, bakers won't be able"
+    echo "    to communicate."
+    echo "  [--encrypted]. Define whether generated baker secret key will be encrypted"
+}
+
+
+if [[ $# -eq 0 || $1 == "--help" ]]; then
+    usage
+    exit 1
+fi
+
+stop_flag="false"
+encrypted_flag="false"
+peers=()
+
+while true; do
+    if [[ $# -eq 0 ]]; then
+        break
+    fi
+    case "$1" in
+        --base-dir | -d )
+            base_dir="$2"
+            shift 2
+            ;;
+        --peer | -p)
+            peers+=("$2")
+            shift 2
+            ;;
+        --tezos-client)
+            tezos_client="$2"
+            shift 2
+            ;;
+        --tezos-node)
+            tezos_node="$2"
+            shift 2
+            ;;
+        --tezos-baker)
+            tezos_baker="$2"
+            shift 2
+            ;;
+        --tezos-endorser)
+            tezos_endorser="$2"
+            shift 2
+            ;;
+        --net-addr)
+            net_addr="$2"
+            shift 2
+            ;;
+        --encrypted)
+            encrypted_flag="true"
+            shift
+            ;;
+        stop)
+            stop_flag="true"
+            shift
+            ;;
+        *)
+            echo "Unexpected option \"$1\"."
+            usage
+            exit 1
+            ;;
+    esac
+done
+
+if [[ $stop_flag == "true" ]]; then
+    kill -15 "$(<"$base_dir"/node_pid.txt)"
+    exit 0
+fi
+
+exit_flag="false"
+
+if [[ -z ${base_dir-} ]]; then
+    echo "\"--base-dir\" wasn't provided."
+    exit_flag="true"
+fi
+
+if [[ -z ${tezos_client-} ]]; then
+    echo "\"--tezos-client\" wasn't provided."
+    exit_flag="true"
+fi
+
+if [[ -z ${tezos_node-} ]]; then
+    echo "\"--tezos-node\" wasn't provided."
+    exit_flag="true"
+fi
+
+if [[ -z ${tezos_baker-} ]]; then
+    echo "\"--tezos-baker\" wasn't provided."
+    exit_flag="true"
+fi
+
+if [[ -z ${tezos_endorser-} ]]; then
+    echo "\"--tezos-endorser\" wasn't provided."
+    exit_flag="true"
+fi
+
+if [[ -z ${net_addr-} ]]; then
+    echo "\"--net-addr\" wasn't provided."
+    exit_flag="true"
+fi
+
+[[ $exit_flag == "true" ]] && exit 1
+
+mkdir -p "$base_dir"
+node_dir="$base_dir/node"
+client_dir="$base_dir/client"
+mkdir -p "$node_dir"
+mkdir -p "$client_dir"
+
+"$tezos_client" -d "$client_dir" show address baker || gen_baker_account
+[[ -f $node_dir/identity.json ]] || gen_node_identity
+start_node
+sleep 5s
+start_baker
+start_endorser


### PR DESCRIPTION
Scripts for building patched binaries, starting baker and activating new protocol are added, along
with a description of how to use them.

Apart from that, a simple CI setup with reuse, crossref-verifier, and shellcheck added.