### PR TITLE
[#7] scripts and docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: 2019 TQ Tezos <https://tqtezos.com/>
+#
+# SPDX-License-Identifier: MPL-2.0
+FROM ubuntu
+RUN apt-get update && apt-get install -y rsync git m4 build-essential patch unzip \
+  bubblewrap wget pkg-config libgmp-dev libev-dev libhidapi-dev
+RUN wget https://github.com/ocaml/opam/releases/download/2.0.3/opam-2.0.3-x86_64-linux && \
+  cp opam-2.0.3-x86_64-linux /usr/local/bin/opam && chmod a+x /usr/local/bin/opam
+COPY ./scripts/ /scripts
+COPY ./patches/ /patches
+RUN mkdir /base-dir
+VOLUME /base-dir
+ENTRYPOINT ["/scripts/docker.sh"]
+EXPOSE 8732
+CMD []

--- a/parameters/parameters_babylonnet.json
+++ b/parameters/parameters_babylonnet.json
@@ -1,0 +1,45 @@
+{
+  "bootstrap_accounts": [
+    [
+      "edpkubXzL1rs3dQAGEdTyevfxLw3pBCTF53CdWKdJJYiBFwC1xZSct",
+      "4000000000000"
+    ],
+    [
+      "edpkvUS1z9QGXr6f89dNF5WyeRCFuK6PYWYrMHcpU9kQ2TevD66fDG",
+      "4000000000000"
+    ],
+    [
+      "edpktezaD1wnUa5pT2pvj1JGHNey18WGhPc9fk9bbppD33KNQ2vH8R",
+      "4000000000000"
+    ]
+  ],
+  "preserved_cycles": 2,
+  "blocks_per_cycle": 8,
+  "blocks_per_commitment": 4,
+  "blocks_per_roll_snapshot": 4,
+  "blocks_per_voting_period": 64,
+  "time_between_blocks": [
+    "10",
+    "20"
+  ],
+  "endorsers_per_block": 32,
+  "hard_gas_limit_per_operation": "800000",
+  "hard_gas_limit_per_block": "8000000",
+  "proof_of_work_threshold": "-1",
+  "tokens_per_roll": "8000000000",
+  "michelson_maximum_type_size": 1000,
+  "seed_nonce_revelation_tip": "125000",
+  "origination_size": 257,
+  "block_security_deposit": "512000000",
+  "endorsement_security_deposit": "64000000",
+  "block_reward": "16000000",
+  "endorsement_reward": "2000000",
+  "cost_per_byte": "1000",
+  "hard_storage_limit_per_operation": "60000",
+  "test_chain_duration": "1966080",
+  "quorum_min": 2000,
+  "quorum_max": 7000,
+  "min_proposal_quorum": 500,
+  "initial_endorsers": 1,
+  "delay_per_missing_endorsement": "1"
+}

--- a/parameters/parameters_babylonnet.json.license
+++ b/parameters/parameters_babylonnet.json.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2020 TQ Tezos <https://tqtezos.com/>
+SPDX-License-Identifier: MPL-2.0

--- a/parameters/parameters_carthagenet.json
+++ b/parameters/parameters_carthagenet.json
@@ -1,0 +1,45 @@
+{
+  "bootstrap_accounts": [
+    [
+      "edpkubXzL1rs3dQAGEdTyevfxLw3pBCTF53CdWKdJJYiBFwC1xZSct",
+      "4000000000000"
+    ],
+    [
+      "edpkvUS1z9QGXr6f89dNF5WyeRCFuK6PYWYrMHcpU9kQ2TevD66fDG",
+      "4000000000000"
+    ],
+    [
+      "edpktezaD1wnUa5pT2pvj1JGHNey18WGhPc9fk9bbppD33KNQ2vH8R",
+      "4000000000000"
+    ]
+  ],
+  "preserved_cycles": 2,
+  "blocks_per_cycle": 8,
+  "blocks_per_commitment": 4,
+  "blocks_per_roll_snapshot": 4,
+  "blocks_per_voting_period": 64,
+  "time_between_blocks": [
+    "10",
+    "20"
+  ],
+  "endorsers_per_block": 32,
+  "hard_gas_limit_per_operation": "800000",
+  "hard_gas_limit_per_block": "8000000",
+  "proof_of_work_threshold": "-1",
+  "tokens_per_roll": "8000000000",
+  "michelson_maximum_type_size": 1000,
+  "seed_nonce_revelation_tip": "125000",
+  "origination_size": 257,
+  "block_security_deposit": "512000000",
+  "endorsement_security_deposit": "64000000",
+  "endorsement_reward": [ "2000000" ],
+  "cost_per_byte": "1000",
+  "hard_storage_limit_per_operation": "60000",
+  "test_chain_duration": "1966080",
+  "quorum_min": 2000,
+  "quorum_max": 7000,
+  "min_proposal_quorum": 500,
+  "initial_endorsers": 1,
+  "delay_per_missing_endorsement": "1",
+  "baking_reward_per_endorsement": [ "200000" ]
+}

--- a/parameters/parameters_carthagenet.json.license
+++ b/parameters/parameters_carthagenet.json.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2020 TQ Tezos <https://tqtezos.com/>
+SPDX-License-Identifier: MPL-2.0

--- a/patches/patch_template.patch
+++ b/patches/patch_template.patch
@@ -1,0 +1,26 @@
+diff --git a/src/proto_genesis_babylonnet/lib_protocol/data.ml b/src/proto_genesis_babylonnet/lib_protocol/data.ml
+index 061e8c8..f89b553 100644
+--- a/src/proto_genesis_babylonnet/lib_protocol/data.ml
++++ b/src/proto_genesis_babylonnet/lib_protocol/data.ml
+@@ -102,7 +102,7 @@ module Pubkey = struct
+ 
+   let default =
+     Signature.Public_key.of_b58check_exn
+-      "edpkugeDwmwuwyyD3Q5enapgEYDxZLtEUFFSrvVwXASQMVEqsvTqWu"
++      "genesis_key_placeholder"
+ 
+   let get_pubkey ctxt =
+     Context.get ctxt pubkey_key >>= function
+diff --git a/src/proto_genesis_carthagenet/lib_protocol/data.ml b/src/proto_genesis_carthagenet/lib_protocol/data.ml
+index 3956b88..f89b553 100644
+--- a/src/proto_genesis_carthagenet/lib_protocol/data.ml
++++ b/src/proto_genesis_carthagenet/lib_protocol/data.ml
+@@ -102,7 +102,7 @@ module Pubkey = struct
+ 
+   let default =
+     Signature.Public_key.of_b58check_exn
+-      "edpktiJknwZ8rQkkZdQUBVmG8Goau6C6JBTMX1hohxMGsQAG1qfFze"
++      "genesis_key_placeholder"
+ 
+   let get_pubkey ctxt =
+     Context.get ctxt pubkey_key >>= function

--- a/patches/patch_template.patch.license
+++ b/patches/patch_template.patch.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: 2020 TQ Tezos <https://tqtezos.com/>
+SPDX-License-Identifier: MPL-2.0

--- a/scripts/activate-protocol.sh
+++ b/scripts/activate-protocol.sh
@@ -23,18 +23,20 @@ usage() {
     echo "  --tezos-client <filepath>. Path for patched tezos-client executable"
     echo "  --parameters <filepath>. Path to JSON file with protocol parameters."
     echo "  [--fitness <int>]. Protocol activation fitness, default value is $fitness."
-    echo "  [--protocol <protocol-name>]. Protocol to activate, default value is"
-    echo "  $protocol"
-
+    echo "  [--base-chain <babylonnet | carthagenet>]. Define base chain for your private"
+    echo "    blockchain. Default is 'carthagenet'."
 }
 
-protocol="PsBabyM1eUXZseaJdmXFApDSBqj8YBfwELoxZHHW77EMcAbbwAS"
 fitness="25"
 
 if [[ $# -eq 0 || $1 == "--help" ]]; then
     usage
     exit 1
 fi
+
+base_chain="carthagenet"
+carthagenet_protocol="PsCARTHAGazKbHtnKfLzQg3kms52kSRpgnDY982a9oYsSXRLQEb"
+babylonnet_protocol="PsBabyM1eUXZseaJdmXFApDSBqj8YBfwELoxZHHW77EMcAbbwAS"
 
 while true; do
     if [[ $# -eq 0 ]]; then
@@ -53,12 +55,12 @@ while true; do
             parameters="$2"
             shift 2
             ;;
-        --fitness)
-            fitness="$2"
+        --base-chain )
+            base_chain="$2"
             shift 2
             ;;
-        --procotol)
-            protocol="$2"
+        --fitness)
+            fitness="$2"
             shift 2
             ;;
         *)
@@ -87,6 +89,19 @@ if [[ -z ${parameters:-} ]]; then
 fi
 
 [[ $exit_flag == "true" ]] && exit 1
+
+case "$base_chain" in
+    babylonnet )
+        protocol="$babylonnet_protocol"
+        ;;
+    carthagenet )
+        protocol="$carthagenet_protocol"
+        ;;
+    *)
+        echo "$base_chain not supported. Only 'babylonnet' and 'carthagenet' are supported."
+        exit 1
+        ;;
+esac
 
 mkdir -p "$base_dir"
 client_dir="$base_dir/client"

--- a/scripts/build-patched-binaries.sh
+++ b/scripts/build-patched-binaries.sh
@@ -114,7 +114,7 @@ git clone --single-branch --branch master https://gitlab.com/tezos/tezos.git --d
 cd tezos
 git apply "../$patch_file"
 
-opam init --bare
+opam init --bare --disable-sandboxing
 make build-deps && eval "$(opam env)" && make
 chmod +x tezos-*
 cp tezos-client ../

--- a/scripts/docker.sh
+++ b/scripts/docker.sh
@@ -1,0 +1,82 @@
+#! /usr/bin/env bash
+# SPDX-FileCopyrightText: 2019 TQ Tezos <https://tqtezos.com/>
+#
+# SPDX-License-Identifier: MPL-2.0
+
+set -euo pipefail
+
+script_args=()
+
+usage () {
+    echo "This script is used to wrap building and baker starting scripts"
+    echo "inside docker container."
+    echo "COMMANDS:"
+    echo "  build-binaries [--base-chain <babylonnet | carthagenet>]"
+    echo "                 [--genesis-key <public-key>]"
+    echo "                 [--encrypted]"
+    echo "    Call 'build-patched-binaries.sh' script inside docker container."
+    echo "    Produced binaries will be stored in '/base-dir' directory inside"
+    echo "    docker container."
+    echo "  start-baker --net-addr-port <port>"
+    echo "              [--base-chain <babylonnet | carthagenet>]"
+    echo "              [--peer <net-addr>]"
+    echo "    Call 'start-baker.sh' script inside docker container."
+    echo "    Will use binaries from '/base-dir' directory and 'localhost' as '--net-addr'"
+}
+
+if [[ $# -eq 0 || $1 == "--help" ]]; then
+    usage
+    exit 1
+fi
+
+case "$1" in
+    build-binaries )
+        script="build"
+        ;;
+    start-baker )
+        script="start"
+        ;;
+    * )
+        "Unexpected command \"$1\""
+        exit 1
+        ;;
+esac
+shift
+
+while true; do
+    if [[ $# -eq 0 ]]; then
+        break
+    fi
+    case "$1" in
+        --net-addr-port )
+            if [[ $script != "start" ]]; then
+                echo "Unexpected option '--net-addr-port' for $script command."
+                exit 1
+            fi
+            port="$2"
+            shift 2
+            ;;
+        *)
+            script_args+=("$1")
+            shift
+            ;;
+    esac
+done
+
+case "$script" in
+    build )
+        "./scripts/build-patched-binaries.sh" "--base-dir" "/base-dir" \
+          "--patch-template" "/patches/patch_template.patch" "${script_args[@]}"
+        ;;
+    start )
+        "./scripts/start-baker.sh" "--base-dir" "/base-dir" "--tezos-client" "/base-dir/tezos-client" \
+          "--tezos-node" "/base-dir/tezos-node" "--tezos-baker" "/base-dir/tezos-baker-"* \
+          "--tezos-endorser" "/base-dir/tezos-endorser-"* "--no-background-node" "${script_args[@]}" \
+          "--net-addr" "localhost:$port"
+        ;;
+    *)
+        echo "Unpexpected command \"$script\"."
+        usage
+        exit 1
+        ;;
+esac

--- a/scripts/start-baker.sh
+++ b/scripts/start-baker.sh
@@ -13,7 +13,19 @@ gen_node_identity() {
 }
 
 start_node() {
-    node_args=("--data-dir" "$node_dir" "--rpc-addr" "localhost:8732" "--net-addr" "$net_addr" "--no-bootstrap-peers" "--bootstrap-threshold" "1")
+    case "$base_chain" in
+        babylonnet )
+            network="babylonnet"
+            ;;
+        carthagenet )
+            network="carthagenet"
+            ;;
+        *)
+            echo "$base_chain not supported. Only 'babylonnet' and 'carthagenet' are supported."
+            exit 1
+            ;;
+    esac
+    node_args=("--data-dir" "$node_dir" "--rpc-addr" "localhost:8732" "--net-addr" "$net_addr" "--no-bootstrap-peers" "--bootstrap-threshold" "1" "--network" "$network")
     for peer in "${peers[@]:-}"; do
         node_args+=("--peer" "$peer")
     done
@@ -51,6 +63,8 @@ usage() {
     echo "  --tezos-baker <filepath>. Path for patched tezos-baker executable"
     echo "  --tezos-endorser <filepath>. Path for patched tezos-endorser executable"
     echo "  --net-addr <net-addr>. Define net address of the baker node"
+    echo "  [--base-chain <babylonnet | carthagenet>]. Define base chain for your private"
+    echo "    blockchain. Default is 'carthagenet'."
     echo "  [--peer <net-addr>]. Node peer address. Possible to provide"
     echo "    zero or more peers. Note, that you have to provide at least one peer"
     echo "    for the baker (e.g. use dictator node), otherwise, bakers won't be able"
@@ -66,6 +80,7 @@ fi
 
 stop_flag="false"
 encrypted_flag="false"
+base_chain="carthagenet"
 peers=()
 
 while true; do
@@ -104,6 +119,10 @@ while true; do
         --encrypted)
             encrypted_flag="true"
             shift
+            ;;
+        --base-chain )
+            base_chain="$2"
+            shift 2
             ;;
         stop)
             stop_flag="true"


### PR DESCRIPTION
Added an additional way to run private blockchain using docker. In order to achieve this the following things were updated:
* Added additional flag for `start-baker.sh` to run node in the foreground.
* Dockerfile and `docker.sh` wrapper script added.
* README updated.

Currently based on #6 

Resolves #7 