### PR TITLE
[#10] Use non modified binaries

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,10 +2,7 @@
 #
 # SPDX-License-Identifier: MPL-2.0
 FROM ubuntu
-RUN apt-get update && apt-get install -y rsync git m4 build-essential patch unzip \
-  bubblewrap wget pkg-config libgmp-dev libev-dev libhidapi-dev
-RUN wget https://github.com/ocaml/opam/releases/download/2.0.3/opam-2.0.3-x86_64-linux && \
-  cp opam-2.0.3-x86_64-linux /usr/local/bin/opam && chmod a+x /usr/local/bin/opam
+RUN apt-get update && apt-get install -y wget netbase
 COPY ./scripts/ /scripts
 COPY ./patches/ /patches
 RUN mkdir /base-dir

--- a/scripts/docker.sh
+++ b/scripts/docker.sh
@@ -8,17 +8,16 @@ set -euo pipefail
 script_args=()
 
 usage () {
-    echo "This script is used to wrap building and baker starting scripts"
+    echo "This script is used to wrap binaries fetching and baker starting scripts"
     echo "inside docker container."
     echo "COMMANDS:"
-    echo "  build-binaries [--base-chain <babylonnet | carthagenet>]"
+    echo "  fetch-binaries [--base-chain <babylonnet | carthagenet>]"
     echo "                 [--genesis-key <public-key>]"
     echo "                 [--encrypted]"
-    echo "    Call 'build-patched-binaries.sh' script inside docker container."
+    echo "    Call 'fetch-binaries.sh' script inside docker container."
     echo "    Produced binaries will be stored in '/base-dir' directory inside"
     echo "    docker container."
     echo "  start-baker --net-addr-port <port>"
-    echo "              [--base-chain <babylonnet | carthagenet>]"
     echo "              [--peer <net-addr>]"
     echo "    Call 'start-baker.sh' script inside docker container."
     echo "    Will use binaries from '/base-dir' directory and 'localhost' as '--net-addr'"
@@ -30,8 +29,8 @@ if [[ $# -eq 0 || $1 == "--help" ]]; then
 fi
 
 case "$1" in
-    build-binaries )
-        script="build"
+    fetch-binaries )
+        script="fetch"
         ;;
     start-baker )
         script="start"
@@ -64,9 +63,9 @@ while true; do
 done
 
 case "$script" in
-    build )
-        "./scripts/build-patched-binaries.sh" "--base-dir" "/base-dir" \
-          "--patch-template" "/patches/patch_template.patch" "${script_args[@]}"
+    fetch )
+        "./scripts/fetch-binaries.sh" "--base-dir" "/base-dir" \
+          "${script_args[@]}"
         ;;
     start )
         "./scripts/start-baker.sh" "--base-dir" "/base-dir" "--tezos-client" "/base-dir/tezos-client" \

--- a/scripts/start-baker.sh
+++ b/scripts/start-baker.sh
@@ -13,19 +13,7 @@ gen_node_identity() {
 }
 
 start_node() {
-    case "$base_chain" in
-        babylonnet )
-            network="babylonnet"
-            ;;
-        carthagenet )
-            network="carthagenet"
-            ;;
-        *)
-            echo "$base_chain not supported. Only 'babylonnet' and 'carthagenet' are supported."
-            exit 1
-            ;;
-    esac
-    node_args=("--data-dir" "$node_dir" "--rpc-addr" "localhost:8732" "--net-addr" "$net_addr" "--no-bootstrap-peers" "--bootstrap-threshold" "1" "--network" "$network")
+    node_args=("--data-dir" "$node_dir" "--rpc-addr" "localhost:8732" "--net-addr" "$net_addr" "--no-bootstrap-peers" "--bootstrap-threshold" "1")
     for peer in "${peers[@]:-}"; do
         node_args+=("--peer" "$peer")
     done
@@ -67,8 +55,6 @@ usage() {
     echo "  --tezos-baker <filepath>. Path for patched tezos-baker executable"
     echo "  --tezos-endorser <filepath>. Path for patched tezos-endorser executable"
     echo "  --net-addr <net-addr>. Define net address of the baker node"
-    echo "  [--base-chain <babylonnet | carthagenet>]. Define base chain for your private"
-    echo "    blockchain. Default is 'carthagenet'."
     echo "  [--peer <net-addr>]. Node peer address. Possible to provide"
     echo "    zero or more peers. Note, that you have to provide at least one peer"
     echo "    for the baker (e.g. use dictator node), otherwise, bakers won't be able"
@@ -85,7 +71,6 @@ fi
 
 stop_flag="false"
 encrypted_flag="false"
-base_chain="carthagenet"
 background_flag="true"
 peers=()
 
@@ -125,10 +110,6 @@ while true; do
         --encrypted)
             encrypted_flag="true"
             shift
-            ;;
-        --base-chain )
-            base_chain="$2"
-            shift 2
             ;;
         --no-background-node )
             background_flag="false"


### PR DESCRIPTION
https://gitlab.com/tezos/tezos/-/merge_requests/1624 was merged, we can use non-modified static
binaries from https://github.com/serokell/tezos-packaging now.

Update scripts and instructions to use these binaries.