### PR TITLE
[#19] Unconditionally fetch tezos-client

### DIFF
--- a/scripts/fetch-binaries.sh
+++ b/scripts/fetch-binaries.sh
@@ -8,11 +8,6 @@ set -euo pipefail
 export TEZOS_CLIENT_UNSAFE_DISABLE_DISCLAIMER="Y"
 
 gen_genesis_key() {
-    # download tezos-client if not presented to generate new public key
-    if [[ ! -f $base_dir/tezos-client ]]; then
-        wget https://github.com/serokell/tezos-packaging/releases/download/202004061400/tezos-client \
-        -P "$base_dir/"
-    fi
     tezos_client="$base_dir/tezos-client"
     chmod +x "$tezos_client"
     if [[ $encrypted_flag == "true" ]]; then
@@ -90,6 +85,8 @@ fi
 [[ $exit_flag == "true" ]] && exit 1
 
 mkdir -p "$base_dir"
+wget https://github.com/serokell/tezos-packaging/releases/download/202004061400/tezos-client \
+     -P "$base_dir/"
 client_dir="$base_dir/client"
 mkdir -p "$client_dir"
 node_dir="$base_dir/node"


### PR DESCRIPTION
##  Description
Problem: After a recent update, tezos-client binary was fetched
conditionally only when we don't have provided genesis key and we have
to generate a new one.

Solution: Always fetch tezos-client in fetch-binaries.sh

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #100500 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
Please use keywords to close related issues if they should be closed:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Resolves #19

#### Related changes (conditional)

- [x] I checked whether I should update the [README](../tree/master/README.md)

#### Stylistic guide (mandatory)

- [x] My commits comply with [the policy used in Serokell](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
